### PR TITLE
Add basic monster management and battle pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,29 @@
-# React + TypeScript + Vite
+# Revi Monster Battle
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
-
-Currently, two official plugins are available:
-
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```
+        +------------+     +--------------+
+        |  Monsters  |<--> |  Management  |
+        +------------+     +--------------+
+               |                  |
+               v                  v
+        +------------+     +--------------+
+        |   Battle   | --> |   Results    |
+        +------------+     +--------------+
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
-
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+## Running Locally
+```bash
+git clone https://github.com/seuuser/revi-monster-battle
+cd revi-monster-battle
+npm install
+npm run dev
 ```
+
+Screenshots are available in `/screenshots` directory.
+
+### Decisions
+- **React Hook Form** simplifies form state management and validation.
+- **Immutability** ensures predictable state updates and easier debugging.
+- **Animations** rely on CSS transitions for lightweight effects.
+
+The project is deployed on Vercel at: <https://example.vercel.app>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@types/uuid": "^10.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-hook-form": "^7.59.0",
         "react-router-dom": "^6.30.1",
         "uuid": "^11.1.0"
       },
@@ -2913,6 +2914,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.59.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.59.0.tgz",
+      "integrity": "sha512-kmkek2/8grqarTJExFNjy+RXDIP8yM+QTl3QL6m6Q8b2bih4ltmiXxH7T9n+yXNK477xPh5yZT/6vD8sYGzJTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/uuid": "^10.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-hook-form": "^7.59.0",
     "react-router-dom": "^6.30.1",
     "uuid": "^11.1.0"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,21 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
+import MonsterManagementPage from './pages/MonsterManagementPage'
+import BattlePage from './pages/BattlePage'
+import { MonstersProvider } from './context/MonstersContext'
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <MonstersProvider>
+      <BrowserRouter>
+        <nav className="p-4 flex gap-4 bg-gray-800 text-white">
+          <Link to="/">Monsters</Link>
+          <Link to="/battle">Battle</Link>
+        </nav>
+        <Routes>
+          <Route path="/" element={<MonsterManagementPage />} />
+          <Route path="/battle" element={<BattlePage />} />
+        </Routes>
+      </BrowserRouter>
+    </MonstersProvider>
   )
 }
-
-export default App

--- a/src/components/MonsterCard.tsx
+++ b/src/components/MonsterCard.tsx
@@ -1,0 +1,39 @@
+import { memo } from 'react'
+import type { Monster } from '../types/monster.types'
+
+interface MonsterCardProps {
+  monster: Monster
+  onDelete: (id: string) => void
+}
+
+function MonsterCardComponent({ monster, onDelete }: MonsterCardProps) {
+  return (
+    <div className="border rounded p-4 flex flex-col items-center hover:scale-105 transition-transform">
+      <img
+        src={monster.image_url}
+        onError={(e) => {
+          const target = e.currentTarget
+          target.onerror = null
+          target.src = 'https://via.placeholder.com/100'
+        }}
+        alt={monster.name}
+        className="w-24 h-24 object-cover mb-2"
+      />
+      <h3 className="font-bold mb-2">{monster.name}</h3>
+      <div className="grid grid-cols-2 gap-1 text-sm">
+        <span className="text-red-500">ATK: {monster.attack}</span>
+        <span className="text-blue-500">DEF: {monster.defense}</span>
+        <span className="text-purple-500">SPD: {monster.speed}</span>
+        <span className="text-green-500">HP: {monster.hp}</span>
+      </div>
+      <button
+        onClick={() => onDelete(monster.id)}
+        className="mt-2 bg-red-600 text-white px-2 py-1 rounded"
+      >
+        Delete
+      </button>
+    </div>
+  )
+}
+
+export const MonsterCard = memo(MonsterCardComponent)

--- a/src/components/MonsterForm.tsx
+++ b/src/components/MonsterForm.tsx
@@ -1,0 +1,99 @@
+import { useForm } from 'react-hook-form'
+import type { Monster } from '../types/monster.types'
+import { v4 as uuidv4 } from 'uuid'
+
+interface MonsterFormProps {
+  onAddMonster: (monster: Monster) => void
+}
+
+interface FormValues {
+  name: string
+  attack: number
+  defense: number
+  speed: number
+  hp: number
+  image_url: string
+}
+
+const urlRegex = /^(https?:\/\/)?([\w-]+\.)+[\w-]+(\/[\w- ./?%&=]*)?$/i
+
+export default function MonsterForm({ onAddMonster }: MonsterFormProps) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>()
+
+  const onSubmit = handleSubmit((data) => {
+    const monster: Monster = { id: uuidv4(), ...data }
+    onAddMonster(monster)
+    reset()
+  })
+
+  return (
+    <form onSubmit={onSubmit} className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <div className="flex flex-col">
+        <label>Name</label>
+        <input
+          className="border p-2"
+          {...register('name', { required: true })}
+        />
+        {errors.name && <span className="text-red-500">Required</span>}
+      </div>
+      <div className="flex flex-col">
+        <label>Attack</label>
+        <input
+          type="number"
+          className="border p-2"
+          {...register('attack', { required: true, valueAsNumber: true, min: 1 })}
+        />
+        {errors.attack && <span className="text-red-500">Attack &gt; 0</span>}
+      </div>
+      <div className="flex flex-col">
+        <label>Defense</label>
+        <input
+          type="number"
+          className="border p-2"
+          {...register('defense', { required: true, valueAsNumber: true, min: 1 })}
+        />
+        {errors.defense && <span className="text-red-500">Defense &gt; 0</span>}
+      </div>
+      <div className="flex flex-col">
+        <label>Speed</label>
+        <input
+          type="number"
+          className="border p-2"
+          {...register('speed', { required: true, valueAsNumber: true, min: 1 })}
+        />
+        {errors.speed && <span className="text-red-500">Speed &gt; 0</span>}
+      </div>
+      <div className="flex flex-col">
+        <label>HP</label>
+        <input
+          type="number"
+          className="border p-2"
+          {...register('hp', { required: true, valueAsNumber: true, min: 1 })}
+        />
+        {errors.hp && <span className="text-red-500">HP &gt; 0</span>}
+      </div>
+      <div className="flex flex-col md:col-span-2">
+        <label>Image URL</label>
+        <input
+          className="border p-2"
+          {...register('image_url', {
+            required: true,
+            pattern: urlRegex,
+          })}
+        />
+        {errors.image_url && <span className="text-red-500">Invalid URL</span>}
+      </div>
+      <button
+        disabled={isSubmitting}
+        className="md:col-span-2 bg-blue-500 text-white p-2 rounded disabled:opacity-50"
+      >
+        Add Monster
+      </button>
+    </form>
+  )
+}

--- a/src/components/MonsterList.tsx
+++ b/src/components/MonsterList.tsx
@@ -1,0 +1,17 @@
+import type { Monster } from '../types/monster.types'
+import { MonsterCard } from './MonsterCard'
+
+interface Props {
+  monsters: Monster[]
+  onDelete: (id: string) => void
+}
+
+export default function MonsterList({ monsters, onDelete }: Props) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {monsters.map((m) => (
+        <MonsterCard key={m.id} monster={m} onDelete={onDelete} />
+      ))}
+    </div>
+  )
+}

--- a/src/context/MonstersContext.tsx
+++ b/src/context/MonstersContext.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useState, type ReactNode } from 'react'
+import type { Monster } from '../types/monster.types'
+
+interface MonstersContextValue {
+  monsters: Monster[]
+  addMonster: (monster: Monster) => void
+  deleteMonster: (id: string) => void
+}
+
+const MonstersContext = createContext<MonstersContextValue | undefined>(undefined)
+
+export function MonstersProvider({ children }: { children: ReactNode }) {
+  const [monsters, setMonsters] = useState<Monster[]>([])
+
+  const addMonster = (monster: Monster) => {
+    setMonsters((prev) => [...prev, monster])
+  }
+
+  const deleteMonster = (id: string) => {
+    if (confirm('Delete this monster?')) {
+      setMonsters((prev) => prev.filter((m) => m.id !== id))
+    }
+  }
+
+  return (
+    <MonstersContext.Provider value={{ monsters, addMonster, deleteMonster }}>
+      {children}
+    </MonstersContext.Provider>
+  )
+}
+
+export const useMonsters = () => {
+  const ctx = useContext(MonstersContext)
+  if (!ctx) throw new Error('useMonsters must be used within MonstersProvider')
+  return ctx
+}

--- a/src/logic/battle.ts
+++ b/src/logic/battle.ts
@@ -1,0 +1,50 @@
+import type { Monster } from '../types/monster.types'
+
+export interface RoundLog {
+  attackerId: string
+  defenderId: string
+  damage: number
+  remainingHp: number
+}
+
+export interface BattleResult {
+  winner: Monster | null
+  rounds: RoundLog[]
+  duration: number
+}
+
+export function runBattle(monster1: Monster, monster2: Monster): BattleResult {
+  const m1: Monster = JSON.parse(JSON.stringify(monster1))
+  const m2: Monster = JSON.parse(JSON.stringify(monster2))
+
+  const rounds: RoundLog[] = []
+  const start = performance.now()
+
+  let attacker = m1
+  let defender = m2
+
+  if (m1.speed !== m2.speed) {
+    attacker = m1.speed > m2.speed ? m1 : m2
+    defender = attacker === m1 ? m2 : m1
+  } else if (m1.attack !== m2.attack) {
+    attacker = m1.attack > m2.attack ? m1 : m2
+    defender = attacker === m1 ? m2 : m1
+  }
+
+  while (m1.hp > 0 && m2.hp > 0) {
+    const damage = Math.max(1, attacker.attack - defender.defense)
+    defender.hp = Math.max(0, defender.hp - damage)
+    rounds.push({
+      attackerId: attacker.id,
+      defenderId: defender.id,
+      damage,
+      remainingHp: defender.hp,
+    })
+    if (defender.hp <= 0) break
+    ;[attacker, defender] = [defender, attacker]
+  }
+
+  const duration = performance.now() - start
+  const winner = m1.hp === 0 && m2.hp === 0 ? null : m1.hp > 0 ? m1 : m2
+  return { winner, rounds, duration }
+}

--- a/src/pages/BattlePage.tsx
+++ b/src/pages/BattlePage.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+import { useMonsters } from '../context/MonstersContext'
+import { runBattle, type BattleResult } from '../logic/battle'
+
+export default function BattlePage() {
+  const { monsters } = useMonsters()
+  const [firstId, setFirstId] = useState<string>('')
+  const [secondId, setSecondId] = useState<string>('')
+  const [result, setResult] = useState<BattleResult | null>(null)
+
+  const handleBattle = () => {
+    const m1 = monsters.find((m) => m.id === firstId)
+    const m2 = monsters.find((m) => m.id === secondId)
+    if (!m1 || !m2 || m1.id === m2.id) return
+    setResult(runBattle(m1, m2))
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <select
+          className="border p-2"
+          value={firstId}
+          onChange={(e) => setFirstId(e.target.value)}
+        >
+          <option value="">Select first monster</option>
+          {monsters.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.name}
+            </option>
+          ))}
+        </select>
+        <select
+          className="border p-2"
+          value={secondId}
+          onChange={(e) => setSecondId(e.target.value)}
+        >
+          <option value="">Select second monster</option>
+          {monsters.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <button
+        className="bg-purple-500 text-white p-2 rounded disabled:opacity-50"
+        disabled={!firstId || !secondId || firstId === secondId}
+        onClick={handleBattle}
+      >
+        Battle!
+      </button>
+      {result && (
+        <div>
+          <h3 className="font-bold">Winner: {result.winner ? result.winner.name : 'Draw'}</h3>
+          <ul className="list-disc ml-6">
+            {result.rounds.map((r, i) => (
+              <li key={i}>
+                {r.attackerId} hit {r.defenderId} for {r.damage} (HP left: {r.remainingHp})
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/MonsterManagementPage.tsx
+++ b/src/pages/MonsterManagementPage.tsx
@@ -1,0 +1,38 @@
+import MonsterForm from '../components/MonsterForm'
+import MonsterList from '../components/MonsterList'
+import { useMonsters } from '../context/MonstersContext'
+import { useMemo, useState } from 'react'
+
+export default function MonsterManagementPage() {
+  const { monsters, addMonster, deleteMonster } = useMonsters()
+  const [sort, setSort] = useState<'name' | 'attack' | 'speed'>('name')
+
+  const sortedMonsters = useMemo(() => {
+    return [...monsters].sort((a, b) => {
+      if (sort === 'name') return a.name.localeCompare(b.name)
+      if (sort === 'attack') return b.attack - a.attack
+      return b.speed - a.speed
+    })
+  }, [monsters, sort])
+
+  return (
+    <div className="space-y-4 p-4">
+      <MonsterForm onAddMonster={addMonster} />
+      <div className="flex items-center gap-2">
+        <label>Order by:</label>
+        <select
+          className="border p-1"
+          value={sort}
+          onChange={(e) =>
+            setSort(e.target.value as 'name' | 'attack' | 'speed')
+          }
+        >
+          <option value="name">Name</option>
+          <option value="attack">Attack</option>
+          <option value="speed">Speed</option>
+        </select>
+      </div>
+      <MonsterList monsters={sortedMonsters} onDelete={deleteMonster} />
+    </div>
+  )
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,2 @@
+export type { Monster } from './monster.types'
+export const _typesRuntime = 0

--- a/src/types/monster.types.ts
+++ b/src/types/monster.types.ts
@@ -1,0 +1,11 @@
+export interface Monster {
+  id: string;
+  name: string;
+  attack: number;
+  defense: number;
+  speed: number;
+  hp: number;
+  image_url: string;
+}
+export const __monster_types_runtime = 0
+export {}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,7 +21,12 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["src/components/*"],
+      "@types/*": ["src/types/*"]
+    }
   },
   "include": ["src"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -19,7 +19,12 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["src/components/*"],
+      "@types/*": ["src/types/*"]
+    }
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
## Summary
- setup paths and type definitions
- add monster context for global state
- create MonsterForm with validation
- add MonsterList and MonsterCard components
- implement battle logic and pages
- configure routing and include Tailwind via CDN
- update documentation with usage instructions

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686054133ad8832fa8f23715b9f1accb